### PR TITLE
Made the DemoSection responsive

### DIFF
--- a/website/src/components/DemoSection.tsx
+++ b/website/src/components/DemoSection.tsx
@@ -16,7 +16,7 @@ const DemoSection = () => {
       badge: "Full Overview"
     },
     {
-      title: "Function Call Analysis", 
+      title: "Function Call Analysis",
       description: "Direct and indirect function calls across directories",
       image: functionCallsImage,
       badge: "Call Chains"
@@ -39,7 +39,7 @@ const DemoSection = () => {
           <p className="text-xl text-muted-foreground max-w-3xl mx-auto mb-12">
             Watch how CodeGraphContext transforms complex codebases into interactive knowledge graphs
           </p>
-          
+
           {/* YouTube Video */}
           <div className="max-w-4xl mx-auto mb-16">
             <div className="relative aspect-video rounded-lg overflow-hidden shadow-2xl border border-border/50">
@@ -59,33 +59,41 @@ const DemoSection = () => {
           <h3 className="text-3xl font-bold text-center mb-8">
             Interactive Visualizations
           </h3>
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8">
+          <div className="grid grid-cols-1 md:grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8">
             {visualizations.map((viz, index) => (
-              <Card key={index} className="group hover:shadow-xl transition-all duration-300 border-border/50 overflow-hidden max-w-sm mx-auto lg:max-w-none">
+              <Card key={index} className="group hover:shadow-xl transition-all duration-300 border-border/50 overflow-hidden w-full">
                 <Dialog>
                   <DialogTrigger asChild>
-                    <div className="relative cursor-pointer">
-                      <img 
-                        src={viz.image} 
+                    <div className="relative cursor-pointer md:flex md:items-center lg:block">
+                      <img
+                        src={viz.image}
                         alt={viz.title}
-                        className="w-full h-40 sm:h-48 object-cover group-hover:scale-105 transition-transform duration-300"
+                        className="w-full md:w-1/2 lg:w-full h-40 sm:h-48 md:h-32 lg:h-40 object-cover group-hover:scale-105 transition-transform duration-300"
                       />
                       <Badge className="absolute top-2 left-2 text-xs bg-primary/90 text-primary-foreground">
                         {viz.badge}
                       </Badge>
-                      <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors duration-300 flex items-center justify-center">
+                      <div className="absolute inset-0 md:left-0 md:right-1/2 lg:right-0 bg-black/0 group-hover:bg-black/10 transition-colors duration-300 flex items-center justify-center">
                         <div className="opacity-0 group-hover:opacity-100 transition-opacity duration-300 bg-white/90 rounded-full p-1.5 sm:p-2">
                           <svg className="w-4 h-4 sm:w-6 sm:h-6 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM10 7v3m0 0v3m0-3h3m-3 0H7" />
                           </svg>
                         </div>
                       </div>
+                      <CardContent className="md:w-1/2 lg:w-full p-4 sm:p-6 md:flex md:flex-col md:justify-center lg:block">
+                        <h4 className="text-lg sm:text-xl font-semibold mb-2 sm:mb-3 group-hover:text-primary transition-colors">
+                          {viz.title}
+                        </h4>
+                        <p className="text-sm sm:text-base text-muted-foreground">
+                          {viz.description}
+                        </p>
+                      </CardContent>
                     </div>
                   </DialogTrigger>
                   <DialogContent className="max-w-5xl w-full">
                     <div className="relative">
-                      <img 
-                        src={viz.image} 
+                      <img
+                        src={viz.image}
                         alt={viz.title}
                         className="w-full h-auto max-h-[80vh] object-contain"
                       />
@@ -96,14 +104,6 @@ const DemoSection = () => {
                     </div>
                   </DialogContent>
                 </Dialog>
-                <CardContent className="p-4 sm:p-6">
-                  <h4 className="text-lg sm:text-xl font-semibold mb-2 sm:mb-3 group-hover:text-primary transition-colors">
-                    {viz.title}
-                  </h4>
-                  <p className="text-sm sm:text-base text-muted-foreground">
-                    {viz.description}
-                  </p>
-                </CardContent>
               </Card>
             ))}
           </div>


### PR DESCRIPTION
**Solves #112**

### Description

This PR addresses issue #112 and makes the DemoSection more responsive

### Changes Made
1. The cards now take up the entire width instead of just stacking up in flex-col
2. For tablet formats (like ipad), cards are reformatted to have the image and description column wise instead of row wise

### 1. Desktop
<img width="1399" height="661" alt="Screenshot 2025-09-29 at 12 57 31 AM" src="https://github.com/user-attachments/assets/db0e426b-a407-48ac-abb4-972b8bd14416" />


### 2. Tablet
<img width="693" height="673" alt="Screenshot 2025-09-29 at 12 57 45 AM" src="https://github.com/user-attachments/assets/e408454f-b458-4685-992a-d33b629fc3e1" />


### 3. Phone
<img width="456" height="682" alt="Screenshot 2025-09-29 at 12 57 56 AM" src="https://github.com/user-attachments/assets/491b552c-2218-4bb4-a534-55c0008a74a6" />