### PR TITLE
Graceful cancel fix

### DIFF
--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -1127,7 +1127,7 @@ class GraphBuilder:
             error_message=str(e)
             logger.error(f"Failed to build graph for path {path}: {error_message}", exc_info=True)
             if job_id:
-                '''checking if the repo has been deleted or not'''
+                '''checking if the repo got deleted '''
                 if "no such file found" in error_message or "deleted" in error_message or "not found" in error_message:
                     status=JobStatus.CANCELLED
                     

--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -1136,7 +1136,7 @@ class GraphBuilder:
 
                 self.job_manager.update_job(
 
-                    job_id, status=JobStatus.FAILED, end_time=datetime.now(), errors=[error_message]
+                    job_id, status=status, end_time=datetime.now(), errors=[error_message]
                 )
 
     def add_code_to_graph_tool(

--- a/src/codegraphcontext/tools/graph_builder.py
+++ b/src/codegraphcontext/tools/graph_builder.py
@@ -1124,10 +1124,19 @@ class GraphBuilder:
             if job_id:
                 self.job_manager.update_job(job_id, status=JobStatus.COMPLETED, end_time=datetime.now())
         except Exception as e:
-            logger.error(f"Failed to build graph for path {path}: {e}", exc_info=True)
+            error_message=str(e)
+            logger.error(f"Failed to build graph for path {path}: {error_message}", exc_info=True)
             if job_id:
+                '''checking if the repo has been deleted or not'''
+                if "no such file found" in error_message or "deleted" in error_message or "not found" in error_message:
+                    status=JobStatus.CANCELLED
+                    
+                else:
+                    status=JobStatus.FAILED
+
                 self.job_manager.update_job(
-                    job_id, status=JobStatus.FAILED, end_time=datetime.now(), errors=[str(e)]
+
+                    job_id, status=JobStatus.FAILED, end_time=datetime.now(), errors=[error_message]
                 )
 
     def add_code_to_graph_tool(


### PR DESCRIPTION
Fixes #13 — Ensures that if a repo is deleted during indexing, the job is gracefully cancelled instead of failing abruptly.

1)Checks error message for deletion indicators ("no such file", "deleted", "not found")

2)Updates job status to CANCELLED if deletion is detected

3)Preserves error logs for transparency and debugging

# Labels: Hacktoberfest25 bug good first issue