### PR TITLE
Fixed harcoded versioning

### DIFF
--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -1,13 +1,34 @@
 import { Button } from "@/components/ui/button";
 import { Github, ExternalLink, Mail, MapPin, Phone } from "lucide-react";
 import { FaDiscord } from "react-icons/fa";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 const Footer = () => {
   const [email, setEmail] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+   const [version, setVersion] = useState("");
+  useEffect(() => {
+    async function fetchVersion() {
+      try {
+        const res = await fetch(
+          "https://raw.githubusercontent.com/Shashankss1205/CodeGraphContext/main/README.md"
+        );
+        if (!res.ok) throw new Error("Failed to fetch README");
 
+        const text = await res.text();
+        const match = text.match(
+          /\*\*Version:\*\*\s*([0-9]+\.[0-9]+\.[0-9]+)/i
+        );
+        setVersion(match ? match[1] : "N/A");
+      } catch (err) {
+        console.error(err);
+        setVersion("N/A");
+      }
+    }
+
+    fetchVersion();
+  }, []);
   const handleNewsletterSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -204,7 +225,7 @@ const Footer = () => {
             © 2025 CodeGraphContext. Released under the MIT License.
           </p>
           <div className="flex items-center gap-4 text-sm text-muted-foreground">
-            <span>Version 0.1.10</span>
+            <span>Version {version}</span>
             <div className="w-1 h-1 bg-muted-foreground rounded-full" />
             <span>Python 3.8+</span>
             <div className="w-1 h-1 bg-muted-foreground rounded-full" />

--- a/website/src/components/HeroSection.tsx
+++ b/website/src/components/HeroSection.tsx
@@ -7,7 +7,28 @@ import { useState, useEffect } from "react";
 const HeroSection = () => {
   const [stars, setStars] = useState(null);
   const [forks, setForks] = useState(null);
+   const [version, setVersion] = useState("");
+  useEffect(() => {
+    async function fetchVersion() {
+      try {
+        const res = await fetch(
+          "https://raw.githubusercontent.com/Shashankss1205/CodeGraphContext/main/README.md"
+        );
+        if (!res.ok) throw new Error("Failed to fetch README");
 
+        const text = await res.text();
+        const match = text.match(
+          /\*\*Version:\*\*\s*([0-9]+\.[0-9]+\.[0-9]+)/i
+        );
+        setVersion(match ? match[1] : "N/A");
+      } catch (err) {
+        console.error(err);
+        setVersion("N/A");
+      }
+    }
+
+    fetchVersion();
+  }, []);
   useEffect(() => {
     fetch("https://api.github.com/repos/Shashankss1205/CodeGraphContext")
       .then((response) => response.json())
@@ -34,7 +55,7 @@ const HeroSection = () => {
         <div className="animate-float-up">
           <Badge variant="secondary" className="mb-6 text-sm font-medium">
             <div className="w-2 h-2 bg-accent rounded-full mr-2 animate-graph-pulse" />
-            Version 0.1.10 • MIT License
+            Version {version} • MIT License
           </Badge>
           
           <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-bold mb-6 bg-gradient-primary bg-clip-text text-transparent leading-tight">


### PR DESCRIPTION
### 📌 Description

This PR fixes the bug where the website displayed a hardcoded version (`0.1.10`).

* The version number is now dynamically fetched from the **GitHub README**.
* Ensures the site always reflects the latest version listed in the README.
* Removes the need for manual updates when a new release is published.

---

### ✅ Related Issue

Closes #103 

---

### 📷 Screenshots (Optional)

#### Before

The version on the website was **hardcoded** as `0.1.10`.

#### After

The version is now **fetched dynamically** from the GitHub README.
<img width="805" height="496" alt="Screenshot 2025-10-01 at 6 58 47 PM" src="https://github.com/user-attachments/assets/34b18c41-331a-4ea0-b836-d24d9c3efc94" />

<img width="427" height="365" alt="Screenshot 2025-10-01 at 6 58 54 PM" src="https://github.com/user-attachments/assets/1522922d-d57b-41e3-a92f-af250fa84d83" />

---

### ⚠️ Breaking Changes

* None. This update is non-breaking.

---

### ℹ️ Additional Notes

* This approach keeps the website in sync with the README, reducing manual overhead.
* Works seamlessly with future version updates.
