### PR TITLE
feature added ChatGPT Codex setup process

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ If you’re using CodeGraphContext in your project, feel free to open a PR and a
     *   Windsurf
     *   Claude
     *   Gemini CLI
+    *   ChatGPT Codex
 
     Upon successful configuration, `cgc setup` will generate and place the necessary configuration files:
     *   It creates an `mcp.json` file in your current directory for reference.

--- a/src/codegraphcontext/cli/setup_wizard.py
+++ b/src/codegraphcontext/cli/setup_wizard.py
@@ -76,7 +76,7 @@ def _configure_ide(mcp_config):
     questions = [
         {
             "type": "confirm",
-            "message": "Automatically configure your IDE/CLI (VS Code, Cursor, Windsurf, Claude, Gemini, Cline)?",
+            "message": "Automatically configure your IDE/CLI (VS Code, Cursor, Windsurf, Claude, Gemini, ChatGPT Codex, Cline)?",
             "name": "configure_ide",
             "default": True,
         }
@@ -90,7 +90,7 @@ def _configure_ide(mcp_config):
         {
             "type": "list",
             "message": "Choose your IDE/CLI to configure:",
-            "choices": ["VS Code", "Cursor", "Windsurf", "Claude code", "Gemini CLI", "Cline", "None of the above"],
+            "choices": ["VS Code", "Cursor", "Windsurf", "Claude code", "Gemini CLI", "ChatGPT Codex", "Cline", "None of the above"],
             "name": "ide_choice",
         }
     ]
@@ -101,7 +101,7 @@ def _configure_ide(mcp_config):
         console.print("\n[cyan]You can add the MCP server manually to your IDE/CLI.[/cyan]")
         return
 
-    if ide_choice in ["VS Code", "Cursor", "Claude code", "Gemini CLI" , "Cline", "Windsurf"]:
+    if ide_choice in ["VS Code", "Cursor", "Claude code", "Gemini CLI", "ChatGPT Codex", "Cline", "Windsurf"]:
         console.print(f"\n[bold cyan]Configuring for {ide_choice}...[/bold cyan]")
         
         config_paths = {
@@ -129,6 +129,11 @@ def _configure_ide(mcp_config):
             ],
             "Gemini CLI": [
                 Path.home() / ".gemini" / "settings.json"
+            ],
+            "ChatGPT Codex": [
+                Path.home() / ".openai" / "mcp_settings.json",
+                Path.home() / ".config" / "openai" / "settings.json",
+                Path.home() / "AppData" / "Roaming" / "OpenAI" / "settings.json"
             ],
             "Cline": [
                 Path.home() / ".config" / "Code" / "User" / "globalStorage" / "saoudrizwan.claude-dev" / "settings" / "cline_mcp_settings.json",


### PR DESCRIPTION
Summary
This PR adds support for **ChatGPT Codex** in the setup process.

 Changes Made
- Added **ChatGPT Codex** as an option in the setup wizard (alongside Gemini, Claude, Cursor, etc.)
- Integrated configuration path fallbacks for Codex:
- Updated **README.md** and **PKG-INFO** to document ChatGPT Codex support

This enables developers to use **CodeGraphContext** with ChatGPT Codex via MCP, making it easier to provide code context directly to Codex.


---
Closes #76