### PR TITLE
Add Support for Amazon Q Developer Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ mcp.json
 
 # Docker
 docker-compose.yml 
+
+# yaml file for amazon Q developer
+devfile.yaml 

--- a/src/codegraphcontext/cli/setup_wizard.py
+++ b/src/codegraphcontext/cli/setup_wizard.py
@@ -76,7 +76,7 @@ def _configure_ide(mcp_config):
     questions = [
         {
             "type": "confirm",
-            "message": "Automatically configure your IDE/CLI (VS Code, Cursor, Windsurf, Claude, Gemini, Cline, RooCode)?",
+            "message": "Automatically configure your IDE/CLI (VS Code, Cursor, Windsurf, Claude, Gemini, Cline, RooCode, Amazon Q Developer)?",
             "name": "configure_ide",
             "default": True,
         }
@@ -90,7 +90,7 @@ def _configure_ide(mcp_config):
         {
             "type": "list",
             "message": "Choose your IDE/CLI to configure:",
-            "choices": ["VS Code", "Cursor", "Windsurf", "Claude code", "Gemini CLI", "Cline", "RooCode", "None of the above"],
+            "choices": ["VS Code", "Cursor", "Windsurf", "Claude code", "Gemini CLI", "Cline", "RooCode", "Amazon Q Developer", "None of the above"],
             "name": "ide_choice",
         }
     ]
@@ -101,7 +101,7 @@ def _configure_ide(mcp_config):
         console.print("\n[cyan]You can add the MCP server manually to your IDE/CLI.[/cyan]")
         return
 
-    if ide_choice in ["VS Code", "Cursor", "Claude code", "Gemini CLI" , "Cline", "Windsurf", "RooCode"]:
+    if ide_choice in ["VS Code", "Cursor", "Claude code", "Gemini CLI" , "Cline", "Windsurf", "RooCode", "Amazon Q Developer"]:
         console.print(f"\n[bold cyan]Configuring for {ide_choice}...[/bold cyan]")
         
         config_paths = {

--- a/src/codegraphcontext/cli/setup_wizard.py
+++ b/src/codegraphcontext/cli/setup_wizard.py
@@ -8,6 +8,7 @@ import time
 import json
 import sys
 import shutil
+import yaml 
 
 console = Console()
 
@@ -71,6 +72,16 @@ def _generate_mcp_json(creds):
     console.print(f"[cyan]Neo4j credentials also saved to: {env_file}[/cyan]")
     _configure_ide(mcp_config)
 
+def convert_mcp_json_to_yaml():
+    json_path = Path.cwd() / "mcp.json"
+    yaml_path = Path.cwd() / "devfile.yaml"
+    if json_path.exists():
+        with open(json_path, "r") as json_file:
+            mcp_config = json.load(json_file)
+        with open(yaml_path, "w") as yaml_file:
+            yaml.dump(mcp_config, yaml_file, default_flow_style=False)
+        console.print(f"[green]Generated devfile.yaml for Amazon Q Developer at {yaml_path}[/green]")
+
 def _configure_ide(mcp_config):
     """Asks user for their IDE and configures it automatically."""
     questions = [
@@ -103,6 +114,10 @@ def _configure_ide(mcp_config):
 
     if ide_choice in ["VS Code", "Cursor", "Claude code", "Gemini CLI" , "Cline", "Windsurf", "RooCode", "Amazon Q Developer"]:
         console.print(f"\n[bold cyan]Configuring for {ide_choice}...[/bold cyan]")
+
+        if ide_choice == "Amazon Q Developer":
+            convert_mcp_json_to_yaml()
+            return  
         
         config_paths = {
             "VS Code": [


### PR DESCRIPTION
This PR introduces integration support for Amazon Q Developer within the MCP environment.
->Enabled configuration and detection for Amazon Q Developer in the setup wizard and CLI.
-> Automated generation and handling of the required YAML configuration (devfile.yaml) for Amazon Q Developer compatibility.

Related Issue
This PR addresses and closes #81