### PR TITLE
Add support for dark mode in ShowStarGraph component

### DIFF
--- a/website/src/components/ShowStarGraph.tsx
+++ b/website/src/components/ShowStarGraph.tsx
@@ -15,6 +15,7 @@ export default function ShowStarGraph() {
   
   // Add cache busting parameter to force updates
   const starHistoryImageUrl = `${baseStarHistoryImageUrl}&t=${refreshKey}`;
+  const starHistoryDarkImageUrl = `${baseStarHistoryImageUrl}&theme=dark&t=${refreshKey}`;
   
   const githubRepoUrl = "https://github.com/Shashankss1205/CodeGraphContext";
   const starHistoryUrl =
@@ -107,16 +108,19 @@ export default function ShowStarGraph() {
                   </div>
                 )}
 
-                <img
-                  src={starHistoryImageUrl}
-                  alt="CodeGraphContext Star History"
-                  className={`w-full h-auto rounded-lg transition-opacity duration-300 ${
-                    imageLoaded && !isRefreshing ? "opacity-100" : "opacity-0 absolute inset-0"
-                  } ${imageError ? "hidden" : "block"}`}
-                  onLoad={handleImageLoad}
-                  onError={handleImageError}
-                  key={refreshKey}
-                />
+                <picture key={refreshKey}>
+                  <source media="(prefers-color-scheme: dark)" srcSet={starHistoryDarkImageUrl} />
+                  <source media="(prefers-color-scheme: light)" srcSet={starHistoryImageUrl} />
+                  <img
+                    src={starHistoryImageUrl}
+                    alt="CodeGraphContext Star History"
+                    className={`w-full h-auto rounded-lg transition-opacity duration-300 ${
+                      imageLoaded && !isRefreshing ? "opacity-100" : "opacity-0 absolute inset-0"
+                    } ${imageError ? "hidden" : "block"}`}
+                    onLoad={handleImageLoad}
+                    onError={handleImageError}
+                  />
+                </picture>
               </div>
 
               {imageLoaded && !isRefreshing && (


### PR DESCRIPTION
This pull request updates the `ShowStarGraph` component to improve the way the star history image is displayed, adding support for light and dark themes using the `<picture>` element and theme-specific image URLs. The most important changes are:

**Theme-aware image rendering:**

* Added a `starHistoryDarkImageUrl` variable to provide a dark-themed image URL for the star history graph.
* Replaced the direct `<img>` usage with a `<picture>` element that serves the appropriate image based on the user's color scheme preference (`prefers-color-scheme: dark` or `light`). [[1]](diffhunk://#diff-f6264528910c9ae3a6466aebefa57b6976b065e58cf8031f5bfd7a0ad73e0e67R111-R113) [[2]](diffhunk://#diff-f6264528910c9ae3a6466aebefa57b6976b065e58cf8031f5bfd7a0ad73e0e67L118-R123)
