### PR TITLE
Added dark/light mode toggle button with light mode classes #102

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1,6 +1,7 @@
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { ThemeProvider } from "@/components/ThemeProvider";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
@@ -11,20 +12,27 @@ const queryClient = new QueryClient();
 
 const App: React.FC = () => (
   <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="dark"
+      enableSystem
+      disableTransitionOnChange
+    >
+      <TooltipProvider>
+        <Toaster />
+        <Sonner />
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Index />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
 
-      {/* Move to Top button */}
-      <MoveToTop />
-    </TooltipProvider>
+        {/* Move to Top button */}
+        <MoveToTop />
+      </TooltipProvider>
+    </ThemeProvider>
   </QueryClientProvider>
 );
 

--- a/website/src/components/ExamplesSection.tsx
+++ b/website/src/components/ExamplesSection.tsx
@@ -58,19 +58,19 @@ const ExamplesSection = () => {
           {examples.map((example, index) => (
             <Card 
               key={index}
-              className="bg-gradient-card border-border/50 hover:border-primary/30 transition-smooth group animate-float-up"
+              className="border-border/50 hover:border-primary/30 transition-smooth group animate-float-up dark:bg-gradient-card dark:bg-card/50 dark:border-border/30 dark:hover:border-primary/40 bg-white/95 border-gray-200/50 hover:border-primary/50 shadow-sm"
               style={{ animationDelay: `${index * 0.15}s` }}
             >
               <CardHeader>
                 <div className="flex items-center gap-4 mb-4">
-                  <div className="p-3 rounded-xl bg-primary/10 border border-primary/20 group-hover:bg-primary/20 transition-smooth">
+                  <div className="p-3 rounded-xl bg-primary/5 border border-primary/15 group-hover:bg-primary/10 transition-smooth dark:bg-primary/20 dark:border-primary/30">
                     <example.icon className="h-6 w-6 text-primary" />
                   </div>
                   <div>
                     <Badge variant="secondary" className="mb-2">
                       {example.category}
                     </Badge>
-                    <CardTitle className="text-xl font-semibold">
+                    <CardTitle className="text-xl font-semibold dark:text-foreground text-gray-900">
                       {example.title}
                     </CardTitle>
                   </div>
@@ -81,9 +81,9 @@ const ExamplesSection = () => {
                   {example.examples.map((exampleText, exampleIndex) => (
                     <div 
                       key={exampleIndex}
-                      className="code-block border-l-4 border-l-accent/30 pl-4 hover:border-l-accent/60 transition-smooth"
+                      className="code-block border-l-4 border-l-accent/30 pl-4 hover:border-l-accent/60 transition-smooth bg-white/95 bg-none border border-gray-200 shadow-sm dark:bg-card dark:border-border"
                     >
-                      <p className="text-sm text-muted-foreground italic">
+                      <p className="text-sm text-muted-foreground italic dark:text-muted-foreground text-gray-600">
                         "{exampleText}"
                       </p>
                     </div>
@@ -96,15 +96,15 @@ const ExamplesSection = () => {
         
         {/* CTA */}
         <div className="text-center mt-16">
-          <Card className="bg-gradient-card border-primary/20 max-w-2xl mx-auto">
+          <Card className="dark:bg-gradient-card dark:bg-card/50 dark:border-border/30 bg-white/95 border-gray-200/50 max-w-2xl mx-auto shadow-sm">
             <CardContent className="pt-8">
               <h3 className="text-2xl font-bold mb-4">
                 Ready to enhance your AI assistant?
               </h3>
-              <p className="text-muted-foreground mb-6">
+              <p className="text-muted-foreground mb-6 dark:text-muted-foreground text-gray-600">
                 Start building intelligent code understanding today with CodeGraphContext
               </p>
-              <div className="code-block max-w-md mx-auto">
+              <div className="code-block max-w-md mx-auto bg-white/95 bg-none border border-gray-200 shadow-sm dark:bg-card dark:border-border">
                 <code className="text-accent">
                   $ pip install codegraphcontext
                 </code>

--- a/website/src/components/FeaturesSection.tsx
+++ b/website/src/components/FeaturesSection.tsx
@@ -45,17 +45,17 @@ const FeaturesSection = () => {
           {features.map((feature, index) => (
             <Card 
               key={index} 
-              className="bg-gradient-card border-border/50 hover:border-primary/30 transition-smooth group hover:shadow-glow animate-float-up"
+              className="border-border/50 hover:border-primary/30 transition-smooth group hover:shadow-glow animate-float-up dark:bg-gradient-card dark:bg-card/50 dark:border-border/30 dark:hover:border-primary/40 bg-white/95 border-gray-200/50 hover:border-primary/50 shadow-sm"
               style={{ animationDelay: `${index * 0.1}s` }}
             >
               <CardHeader>
                 <div className="flex items-center gap-4 mb-4">
-                  <div className={`p-3 rounded-xl bg-${feature.color}/10 border border-${feature.color}/20 group-hover:bg-${feature.color}/20 transition-smooth`}>
+                  <div className={`p-3 rounded-xl bg-${feature.color}/10 border border-${feature.color}/20 group-hover:bg-${feature.color}/20 transition-smooth dark:bg-${feature.color}/20 dark:border-${feature.color}/30 bg-${feature.color}/5 border-${feature.color}/15`}>
                     <feature.icon className={`h-6 w-6 text-${feature.color}`} />
                   </div>
-                  <CardTitle className="text-xl font-semibold">{feature.title}</CardTitle>
+                  <CardTitle className="text-xl font-semibold dark:text-foreground text-gray-900">{feature.title}</CardTitle>
                 </div>
-                <CardDescription className="text-base text-muted-foreground leading-relaxed">
+                <CardDescription className="text-base text-muted-foreground leading-relaxed dark:text-muted-foreground text-gray-600">
                   {feature.description}
                 </CardDescription>
               </CardHeader>

--- a/website/src/components/HeroSection.tsx
+++ b/website/src/components/HeroSection.tsx
@@ -5,6 +5,7 @@ import heroGraph from "@/assets/hero-graph.jpg";
 import { useState, useEffect } from "react";
 import ShowDownloads from "./ShowDownloads";
 import ShowStarGraph from "./ShowStarGraph";
+import { ThemeToggle } from "./ThemeToggle";
 
 const HeroSection = () => {
   const [stars, setStars] = useState(null);
@@ -43,6 +44,13 @@ const HeroSection = () => {
 
   return (
     <section className="relative min-h-screen flex items-center justify-center overflow-hidden">
+      {/* Header with Theme Toggle */}
+      <div className="absolute top-0 left-0 right-0 z-20 p-4">
+        <div className="container mx-auto flex justify-end">
+          <ThemeToggle />
+        </div>
+      </div>
+
       {/* Background Image */}
       <div 
         className="absolute inset-0 bg-cover bg-center bg-no-repeat opacity-30"

--- a/website/src/components/InstallationSection.tsx
+++ b/website/src/components/InstallationSection.tsx
@@ -50,7 +50,7 @@ const InstallationSection = () => {
           {installSteps.map((step, index) => (
             <Card 
               key={index}
-              className="bg-gradient-card border-border/50 hover:border-primary/30 transition-smooth animate-float-up"
+              className="border-border/50 hover:border-primary/30 transition-smooth animate-float-up dark:bg-gradient-card dark:bg-card/50 dark:border-border/30 dark:hover:border-primary/40 bg-white/95 border-gray-200/50 hover:border-primary/50 shadow-sm"
               style={{ animationDelay: `${index * 0.2}s` }}
             >
               <CardHeader className="pb-4">
@@ -65,7 +65,7 @@ const InstallationSection = () => {
                 </CardDescription>
               </CardHeader>
               <CardContent>
-                <div className="code-block flex items-center justify-between group">
+                <div className="code-block flex items-center justify-between group bg-white/95 bg-none border border-gray-200 shadow-sm dark:bg-card dark:border-border dark:shadow-lg">
                   <code className="text-accent font-mono animate-code-highlight">
                     $ {step.command}
                   </code>
@@ -84,7 +84,7 @@ const InstallationSection = () => {
         </div>
         
         {/* Setup Options */}
-        <Card className="bg-gradient-card border-border/50">
+        <Card className="dark:bg-gradient-card dark:bg-card/50 dark:border-border/30 bg-white/95 border-gray-200/50">
           <CardHeader>
             <CardTitle className="flex items-center gap-3">
               <Settings className="h-6 w-6 text-primary" />

--- a/website/src/components/ThemeProvider.tsx
+++ b/website/src/components/ThemeProvider.tsx
@@ -1,0 +1,9 @@
+"use client"
+
+import * as React from "react"
+import { ThemeProvider as NextThemesProvider } from "next-themes"
+import { type ThemeProviderProps } from "next-themes/dist/types"
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}

--- a/website/src/components/ThemeToggle.tsx
+++ b/website/src/components/ThemeToggle.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import * as React from "react"
+import { Moon, Sun } from "lucide-react"
+import { useTheme } from "next-themes"
+
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+export function ThemeToggle() {
+  const { setTheme } = useTheme()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon">
+          <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          System
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}


### PR DESCRIPTION
PR Description
✅ Changes Implemented

Added a dark/light theme toggle button using [next-themes](https://github.com/pacocoursey/next-themes)
with ShadCN components.
Updated relevant sections to ensure proper rendering in both dark and light modes.
Fixed styling inconsistencies that caused visibility issues in light theme.

📸 Screenshots

<img width="1897" height="911" alt="Screenshot 2025-10-02 140741" src="https://github.com/user-attachments/assets/aa2ac7e9-2049-45d2-9466-c05134724da5" />
<img width="1898" height="916" alt="Screenshot 2025-10-02 140754" src="https://github.com/user-attachments/assets/4ae1114c-b16f-4658-977d-845566a38e4b" />
<img width="1895" height="916" alt="Screenshot 2025-10-02 140816" src="https://github.com/user-attachments/assets/45e0f70a-fa75-4998-9582-d90e3aa647e8" />

📝 Notes

The toggle is fully functional and persists user preference.
Verified across different components for consistent styling.

