### PR TITLE
Run pytest in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-  schedule:
+  schedule:  # Runs at 18:30 each day
     - cron: "30 18 * * *"
   workflow_dispatch:  
 
@@ -15,18 +15,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: 3.x
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install build
           pip install .[dev]
+
+      - name: Run tests
+        run: pytest
 
       - name: Build package
         run: python -m build


### PR DESCRIPTION
* https://github.com/actions/checkout/releases
* https://github.com/actions/setup-python/releases

Automated testing should tell us if things are broken on the latest stable version of Python before users do.
* https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#using-the-python-version-input
> [x-ranges](https://github.com/npm/node-semver#x-ranges-12x-1x-12-) to specify the latest stable version of Python (for the specified major version): 