### PR TITLE
fixed refreshing and layout shift

### DIFF
--- a/website/src/components/ShowStarGraph.tsx
+++ b/website/src/components/ShowStarGraph.tsx
@@ -2,7 +2,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ExternalLink, Star, TrendingUp, RefreshCw } from "lucide-react";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 
 export default function ShowStarGraph() {
   const [imageLoaded, setImageLoaded] = useState(false);
@@ -12,11 +12,11 @@ export default function ShowStarGraph() {
 
   const baseStarHistoryImageUrl =
     "https://api.star-history.com/svg?repos=Shashankss1205/CodeGraphContext&type=Date";
-  
+
   // Add cache busting parameter to force updates
   const starHistoryImageUrl = `${baseStarHistoryImageUrl}&t=${refreshKey}`;
   const starHistoryDarkImageUrl = `${baseStarHistoryImageUrl}&theme=dark&t=${refreshKey}`;
-  
+
   const githubRepoUrl = "https://github.com/Shashankss1205/CodeGraphContext";
   const starHistoryUrl =
     "https://star-history.com/#Shashankss1205/CodeGraphContext&Date";
@@ -37,8 +37,19 @@ export default function ShowStarGraph() {
     setIsRefreshing(true);
     setImageLoaded(false);
     setImageError(false);
-    setRefreshKey(prev => prev + 1);
+    setRefreshKey((prev) => prev + 1);
   }, []);
+
+  //Refreshed the graph everyday
+   useEffect(() => {
+    const today = new Date().toDateString();
+    const lastUpdated = localStorage.getItem("starHistoryLastUpdate");
+
+    if (lastUpdated !== today) {
+      handleRefresh();
+      localStorage.setItem("starHistoryLastUpdate", today);
+    }
+  }, [handleRefresh]);
 
   return (
     <>
@@ -66,29 +77,23 @@ export default function ShowStarGraph() {
                 <Badge variant="outline" className="ml-2">
                   Updated Daily
                 </Badge>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleRefresh}
-                  disabled={isRefreshing}
-                  className="ml-2 h-8 w-8 p-0"
-                >
-                  <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
-                </Button>
               </CardTitle>
             </CardHeader>
             <CardContent className="p-6">
               <div className="relative">
-                {(!imageLoaded && !imageError) || isRefreshing && (
-                  <div className="w-full h-64 bg-muted rounded-lg flex items-center justify-center">
-                    <div className="text-center">
-                      <div className="animate-spin h-8 w-8 border-4 border-primary border-t-transparent rounded-full mx-auto mb-2"></div>
-                      <p className="text-muted-foreground">
-                        {isRefreshing ? 'Refreshing star history...' : 'Loading star history...'}
-                      </p>
+                {(!imageLoaded && !imageError) ||
+                  (isRefreshing && (
+                    <div className="w-full h-64 bg-muted rounded-lg flex items-center justify-center">
+                      <div className="text-center">
+                        <div className="animate-spin h-8 w-8 border-4 border-primary border-t-transparent rounded-full mx-auto mb-2"></div>
+                        <p className="text-muted-foreground">
+                          {isRefreshing
+                            ? "Refreshing star history..."
+                            : "Loading star history..."}
+                        </p>
+                      </div>
                     </div>
-                  </div>
-                )}
+                  ))}
 
                 {imageError && (
                   <div className="w-full h-64 bg-muted rounded-lg flex items-center justify-center border-2 border-dashed border-border">
@@ -113,7 +118,9 @@ export default function ShowStarGraph() {
                     src={starHistoryImageUrl}
                     alt="CodeGraphContext Star History"
                     className={`w-full h-auto rounded-lg transition-opacity duration-300 dark:hidden ${
-                      imageLoaded && !isRefreshing ? "opacity-100" : "opacity-0 absolute inset-0"
+                      imageLoaded && !isRefreshing
+                        ? "opacity-100"
+                        : "opacity-0 absolute inset-0"
                     } ${imageError ? "hidden" : "block"}`}
                     onLoad={handleImageLoad}
                     onError={handleImageError}
@@ -122,7 +129,9 @@ export default function ShowStarGraph() {
                     src={starHistoryDarkImageUrl}
                     alt="CodeGraphContext Star History"
                     className={`w-full h-auto rounded-lg transition-opacity duration-300 hidden dark:block ${
-                      imageLoaded && !isRefreshing ? "opacity-100" : "opacity-0 absolute inset-0"
+                      imageLoaded && !isRefreshing
+                        ? "opacity-100"
+                        : "opacity-0 absolute inset-0"
                     } ${imageError ? "hidden" : "block"}`}
                     onLoad={handleImageLoad}
                     onError={handleImageError}
@@ -152,15 +161,6 @@ export default function ShowStarGraph() {
                     <ExternalLink className="h-4 w-4" />
                   </Button>
 
-                  <Button
-                    variant="secondary"
-                    onClick={handleRefresh}
-                    disabled={isRefreshing}
-                    className="flex items-center gap-2"
-                  >
-                    <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
-                    Refresh Graph
-                  </Button>
                 </div>
               )}
             </CardContent>


### PR DESCRIPTION
**Title:** ♻️ Auto-refresh Star History Graph Daily

**Description:**

* Removed manual refresh button (UI layout remains unchanged).
* Added automatic daily refresh using date-based logic.
* Ensures the star history graph always stays up-to-date without user interaction.

✅ No layout or styling changes.
✅ Graph updates automatically once per day.

closes #179 

---
<img width="1033" height="710" alt="Screenshot 2025-10-03 at 12 03 53 AM" src="https://github.com/user-attachments/assets/2dbfaff3-57b4-4de9-beda-77c19f12a5a4" />

