### PR TITLE
docs: Update cookbook link and clean up star chart

### DIFF
--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -138,7 +138,7 @@ const Footer = () => {
                 </li>
                 <li>
                   <a
-                    href="https://github.com/Shashankss1205/CodeGraphContext/blob/main/cookbook.md"
+                    href="https://github.com/Shashankss1205/CodeGraphContext/blob/main/docs/cookbook.md"
                     className="hover:text-foreground transition-smooth"
                   >
                     Cookbook


### PR DESCRIPTION
Hi there,

This PR addresses two small documentation issues:
1.  Updated the "Cookbook" link in the footer to point to its new location in the `/docs` folder.
2.  Removed the redundant "Data provided by..." line from under the star history chart as requested.

Let me know if any other changes are needed!
Close #240 