### PR TITLE
fix: swap VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in .example…

### DIFF
--- a/website/.example.env
+++ b/website/.example.env
@@ -1,2 +1,2 @@
-VITE_SUPABASE_ANON_KEY="https://your-project.supabase.co"
-VITE_SUPABASE_URL="your-anon-key"
+VITE_SUPABASE_ANON_KEY="your-anon-key"
+VITE_SUPABASE_URL="https://your-project.supabase.co"


### PR DESCRIPTION
This PR fixes the incorrect values in .example.env where the VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY entries were swapped.
The values have been corrected to match their intended usage.

Linked Issue:
Fixes #260 