### PR TITLE
fix(theme): replace System option with Moon/Sun toggle and set default theme to light

### DIFF
--- a/website/src/components/ThemeToggle.tsx
+++ b/website/src/components/ThemeToggle.tsx
@@ -13,28 +13,27 @@ import {
 } from "@/components/ui/dropdown-menu"
 
 export function ThemeToggle() {
-  const { setTheme } = useTheme()
+  const { setTheme, theme } = useTheme()
+
+  const currentTheme = theme === 'dark' ? 'dark' : 'light'
+
+  const toggleTheme = () => {
+    setTheme(currentTheme === 'dark' ? 'light' : 'dark')
+  }
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon">
-          <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-          <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-          <span className="sr-only">Toggle theme</span>
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={() => setTheme("light")}>
-          Light
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme("dark")}>
-          Dark
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme("system")}>
-          System
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <Button variant="outline" size="icon" onClick={toggleTheme}>
+      <Sun
+        className={`h-[1.2rem] w-[1.2rem] transition-all ${
+          currentTheme === "dark" ? "rotate-0 scale-100" : "rotate-0 scale-0"
+        }`}
+      />
+      <Moon
+        className={`absolute h-[1.2rem] w-[1.2rem] transition-all ${
+          currentTheme === "dark" ? "rotate-0 scale-0" : "rotate-0 scale-100"
+        }`}
+      />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
   )
 }


### PR DESCRIPTION
### What changed
- Removed the "System" option from the theme toggle.
- Replaced dropdown with a single button showing:
  - 🌙 Moon when the site is in light mode
  - ☀️ Sun when the site is in dark mode
- Default theme is now light when the site loads.

### Demo
A short 2–3 second video demonstrating the toggle behavior is attached to the PR.

### Notes
This implementation keeps theme switching simple and aligns with the requested UI behavior.
