### PR TITLE
docs: add combined demo for list_indexed_repositories and delete_rep

### DIFF
--- a/docs/Tools_Exploration.md
+++ b/docs/Tools_Exploration.md
@@ -39,3 +39,62 @@ Below is an embedded link to a demo video showcasing the usage of the `analyse_c
 [![Watch the demo](./images/tool_images/3.png)](https://drive.google.com/file/d/154M_lTPbg9_Gj9bd2ErnAVbJArSbcb2M/view?usp=drive_link) 
 
 ---
+
+## list_indexed_repositories and delete_repository Tools (Combined Demo)
+
+These tools help you manage which repositories are currently indexed in the Neo4j code graph.
+
+- list_indexed_repositories: Returns all repositories present in the graph with their names and paths.
+- delete_repository: Removes a repository (and its nodes/relationships) from the graph by path.
+
+### When to use
+- Use list_indexed_repositories to verify what’s currently indexed before or after indexing/deleting.
+- Use delete_repository to clean up an outdated or unwanted repository before re-indexing it.
+
+### CLI usage
+```bash
+# List indexed repositories
+cgc list_repos
+
+# Delete a repository from the graph by its path
+cgc delete "/absolute/or/project/path"
+```
+
+### Direct tool calls
+```json
+{
+  "tool": "list_indexed_repositories",
+  "args": {}
+}
+```
+```json
+{
+  "tool": "delete_repository",
+  "args": { "repo_path": "/absolute/or/project/path" }
+}
+```
+
+### Expected responses
+- list_indexed_repositories returns:
+```json
+{
+  "success": true,
+  "repositories": [
+    { "name": "sample_project", "path": "/path/to/sample_project", "is_dependency": false }
+  ]
+}
+```
+- delete_repository returns:
+```json
+{
+  "success": true,
+  "message": "Repository '/path/to/sample_project' deleted successfully."
+}
+```
+
+### Demo flow (suggested for video)
+1) Run cgc list_repos and capture the current repositories.
+2) Index a repo if needed (cgc index /path/to/repo), wait for job completion.
+3) Run cgc list_repos again to show the newly indexed repo appears.
+4) Run cgc delete "/path/to/repo" to remove it.
+5) Run cgc list_repos once more to show it no longer appears.


### PR DESCRIPTION
Adds a combined demo section explaining how to use `list_indexed_repositories` and `delete_repository`, including CLI examples and expected responses. 
Addresses #229.

- Adds usage, direct tool-call JSON, and demo flow steps.
- Minimal changes; docs-only update.