### PR TITLE
CI: skip Discord invite job for forked PRs (fixes #254)

### DIFF
--- a/.github/workflows/post_discord_invite.yml
+++ b/.github/workflows/post_discord_invite.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   post_discord_invite:
+    # Skip if the event is a PR from a fork; still run for issues and in-repo PRs
+    if: ${{ github.event_name == 'issues' || (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) }}
     runs-on: ubuntu-latest
     steps:
       - name: Post Discord Invite Comment


### PR DESCRIPTION
Forked PRs were failing on the post_discord_invite workflow with:
HttpError: Resource not accessible by integration

This happens because the default GITHUB_TOKEN in forked PRs is read-only and cannot post comments on the upstream repo.

There's a really simple fix for that. this is what i did:
Added a job-level condition to .github/workflows/post_discord_invite.yml
>> if: ${{ github.event_name == 'issues' || (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) }}
This ensures the job still runs for issues and in-repo PRs, but is skipped for forked PRs.

fixes #254 

