### PR TITLE
enhance package resolver to support C packages and update input schema

### DIFF
--- a/src/codegraphcontext/server.py
+++ b/src/codegraphcontext/server.py
@@ -154,8 +154,8 @@ class MCPServer:
                 "inputSchema": {
                     "type": "object",
                     "properties": {
-                        "package_name": {"type": "string", "description": "Name of the package to add (e.g., 'requests', 'express')."},
-                        "language": {"type": "string", "description": "The programming language of the package.", "enum": ["python", "javascript"]},
+                        "package_name": {"type": "string", "description": "Name of the package to add (e.g., 'requests', 'express', 'iniparser')."},
+                        "language": {"type": "string", "description": "The programming language of the package.", "enum": ["python", "javascript", "c"]},
                         "is_dependency": {"type": "boolean", "description": "Mark as a dependency.", "default": True}
                     },
                     "required": ["package_name", "language"]


### PR DESCRIPTION
Add support for C language package resolution

Fixes #314

Summary:
This PR adds support for C language packages to the add_package_to_graph tool, enabling discovery and indexing of C libraries.

Changes:
- package_resolver.py: Added _get_c_package_path() function that:
  - Uses pkg-config to locate C packages when available
  - Falls back to searching standard system include directories (/usr/include, /usr/local/include, /opt/homebrew/include, etc.)
  - Checks for both package directories and header files
  - Supports local installations in the current directory

- server.py: Updated add_package_to_graph tool to accept "c" as a language option in the enum

Testing:
Successfully tested with cjson package - found at /opt/homebrew/Cellar/cjson/1.7.18/include/cjson

Example Usage:
add_package_to_graph(package_name="iniparser", language="c", is_dependency=True)