### PR TITLE
feat: Add support for Ruby

### DIFF
--- a/src/codegraphcontext/server.py
+++ b/src/codegraphcontext/server.py
@@ -155,7 +155,7 @@ class MCPServer:
                     "type": "object",
                     "properties": {
                         "package_name": {"type": "string", "description": "Name of the package to add (e.g., 'requests', 'express', 'moment', 'lodash')."},
-                        "language": {"type": "string", "description": "The programming language of the package.", "enum": ["python", "javascript", "typescript", "java", "c"]},
+                        "language": {"type": "string", "description": "The programming language of the package.", "enum": ["python", "javascript", "typescript", "java", "c", "ruby"]},
                         "is_dependency": {"type": "boolean", "description": "Mark as a dependency.", "default": True}
                     },
                     "required": ["package_name", "language"]

--- a/src/codegraphcontext/tools/package_resolver.py
+++ b/src/codegraphcontext/tools/package_resolver.py
@@ -227,6 +227,30 @@ def _get_c_package_path(package_name: str) -> Optional[str]:
     except Exception as e:
         debug_log(f"Error getting C package path for {package_name}: {e}")
         return None
+    
+def get_ruby_package_path(package_name: str) -> Optional[str]:
+    """
+    Finds the local installation path of a Ruby gem.
+    """
+    try:
+        debug_log(f"Getting local path for Ruby gem: {package_name}")
+        result = subprocess.run(
+            ["gem", "which", package_name],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            gem_path = Path(result.stdout.strip())
+            if gem_path.exists():
+                return str(gem_path.parent.resolve())
+        return None
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        debug_log(f"gem command not available or timed out for {package_name}")
+        return None
+    except Exception as e:
+        debug_log(f"Error getting Ruby gem path for {package_name}: {e}")
+        return None
 
 def get_local_package_path(package_name: str, language: str) -> Optional[str]:
     """
@@ -238,6 +262,7 @@ def get_local_package_path(package_name: str, language: str) -> Optional[str]:
         "typescript": _get_typescript_package_path,
         "java": _get_java_package_path,
         "c": _get_c_package_path,
+        "ruby": get_ruby_package_path,
     }
     finder = finders.get(language)
     if finder:


### PR DESCRIPTION
This pull request adds support for resolving Ruby package (gem) paths in the codebase. The main changes include updating the language options to include Ruby and implementing logic to find the installation path of Ruby gems.

**Ruby package support:**

* Added "ruby" to the supported `language` enum for package resolution in the `_init_tools` method in `server.py`.
* Implemented the `get_ruby_package_path` function in `package_resolver.py` to locate the local installation path of a Ruby gem using the `gem which` command.
* Updated the `get_local_package_path` dispatcher to support the new Ruby package path finder.

Closes: #320 