### PR TITLE
feat: Add Go support

### DIFF
--- a/src/codegraphcontext/server.py
+++ b/src/codegraphcontext/server.py
@@ -155,8 +155,7 @@ class MCPServer:
                     "type": "object",
                     "properties": {
                         "package_name": {"type": "string", "description": "Name of the package to add (e.g., 'requests', 'express', 'moment', 'lodash')."},
-                        "language": {"type": "string", "description": "The programming language of the package.", "enum": ["python", "javascript", "typescript", "java", "c", "go"]},
-                        "language": {"type": "string", "description": "The programming language of the package.", "enum": ["python", "javascript", "typescript", "java", "c", "ruby"]},
+                        "language": {"type": "string", "description": "The programming language of the package.", "enum": ["python", "javascript", "typescript", "java", "c", "go", "ruby"]},
                         "is_dependency": {"type": "boolean", "description": "Mark as a dependency.", "default": True}
                     },
                     "required": ["package_name", "language"]

--- a/src/codegraphcontext/server.py
+++ b/src/codegraphcontext/server.py
@@ -155,7 +155,7 @@ class MCPServer:
                     "type": "object",
                     "properties": {
                         "package_name": {"type": "string", "description": "Name of the package to add (e.g., 'requests', 'express', 'moment', 'lodash')."},
-                        "language": {"type": "string", "description": "The programming language of the package.", "enum": ["python", "javascript", "typescript", "java", "c"]},
+                        "language": {"type": "string", "description": "The programming language of the package.", "enum": ["python", "javascript", "typescript", "java", "c", "go"]},
                         "is_dependency": {"type": "boolean", "description": "Mark as a dependency.", "default": True}
                     },
                     "required": ["package_name", "language"]

--- a/src/codegraphcontext/tools/package_resolver.py
+++ b/src/codegraphcontext/tools/package_resolver.py
@@ -228,6 +228,64 @@ def _get_c_package_path(package_name: str) -> Optional[str]:
         debug_log(f"Error getting C package path for {package_name}: {e}")
         return None
 
+def _get_go_package_path(package_name: str) -> Optional[str]:
+    """
+    Finds the local installation path of a Go package using `go list`.
+    Tries:
+      1) package dir:   go list -f '{{.Dir}}' <pkg>
+      2) module root:   go list -m -f '{{.Dir}}' <module>
+      3) force mod:     go list -mod=mod -f '{{.Dir}}' <pkg>
+    """
+
+    def _first_existing_dir(output: str) -> Optional[str]:
+        for line in (l.strip().strip("'\"") for l in output.splitlines() if l.strip()):
+            p = Path(line)
+            if p.exists() and p.is_dir():
+                return str(p.resolve())
+        return None
+
+    try:
+        debug_log(f"Getting local path for Go package: {package_name}")
+        # Package directory (works for stdlib, GOPATH, or subpackages)
+        cp = subprocess.run(
+            ["go", "list", "-f", "{{.Dir}}", package_name],
+            capture_output=True, text=True, timeout=15
+        )
+        if cp.returncode == 0:
+            d = _first_existing_dir(cp.stdout)
+            if d:
+                return d
+
+        # Module root directory (where go.mod lives)
+        cp2 = subprocess.run(
+            ["go", "list", "-m", "-f", "{{.Dir}}", package_name],
+            capture_output=True, text=True, timeout=15
+        )
+        if cp2.returncode == 0:
+            d = _first_existing_dir(cp2.stdout)
+            if d:
+                return d
+
+        # Retry forcing module mode
+        cp3 = subprocess.run(
+            ["go", "list", "-mod=mod", "-f", "{{.Dir}}", package_name],
+            capture_output=True, text=True, timeout=15
+        )
+        if cp3.returncode == 0:
+            d = _first_existing_dir(cp3.stdout)
+            if d:
+                return d
+
+        return None
+
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        debug_log(f"go command not available or timed out for {package_name}")
+        return None
+    except Exception:
+        debug_log(f"Error getting Go package path for {package_name}")
+        return None
+
+
 def get_local_package_path(package_name: str, language: str) -> Optional[str]:
     """
     Dispatches to the correct package path finder based on the language.
@@ -238,6 +296,7 @@ def get_local_package_path(package_name: str, language: str) -> Optional[str]:
         "typescript": _get_typescript_package_path,
         "java": _get_java_package_path,
         "c": _get_c_package_path,
+        "go": _get_go_package_path,  
     }
     finder = finders.get(language)
     if finder:


### PR DESCRIPTION
This pull request adds support for resolving Go package paths in the code graph context server. The main changes include updating the language enum to include Go and implementing logic to find the local installation path of Go packages.

**Go language support:**

* Added "go" to the list of supported languages for package resolution in the `_init_tools` method in `server.py`.
* Implemented the `_get_go_package_path` function in `package_resolver.py` to determine the local installation path of Go packages using various `go list` commands.
* Updated the `get_local_package_path` dispatcher to route Go packages to the new `_get_go_package_path` function.